### PR TITLE
replace the relative url of the contribution guide in the issue templ…

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,7 +2,7 @@
 
 - [ ] Have you searched for existing issues (open and close) to see if the bug or feature request has already been reported?
 - [ ] If this is a bug report, are you running the latest version of Assemble? If not, please update to the latest version and verify that the issue still occurs before proceding.
-- [ ] Have you read the [Contributing Guide](contributing.md)?
+- [ ] Have you read the [Contributing Guide](https://github.com/assemble/assemble/blob/master/.github/contributing.md)?
 - [ ] Have you reviewed the project readme (you might find advice about creating new issues)?
 - [ ] Are you creating an issue in the correct repository? (For example, if your issue is related to [grunt-assemble][] or [handlebars-helpers][], you will want to create the issue in that project).
 


### PR DESCRIPTION
…ate by an absolute url

<!-- See https://github.com/doapply/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [x] [Tested with screen reader](https://github.com/doapply/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/doapply/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/doapply/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/doapply/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
